### PR TITLE
Fix crash when fetchEvents handles generic errors

### DIFF
--- a/FindMyUltra/Views/MapViews/MapViewModel.swift
+++ b/FindMyUltra/Views/MapViews/MapViewModel.swift
@@ -94,7 +94,11 @@ final class MapViewModel: NSObject, CLLocationManagerDelegate,ObservableObject {
                     locations.append(location)
                 }
             } catch {
-                errorMessage = "\((error as! ApiError).customDescription)"
+                if let apiError = error as? ApiError {
+                    errorMessage = apiError.customDescription
+                } else {
+                    errorMessage = error.localizedDescription
+                }
                 hasError = true
             }
     }


### PR DESCRIPTION
## Summary
- avoid forced cast to `ApiError` when fetching event data

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683fb654e45c8328b716c5c989c2e9e2