### PR TITLE
Improve error handling in MapViewModel

### DIFF
--- a/FindMyUltra/Views/MapViews/MapViewModel.swift
+++ b/FindMyUltra/Views/MapViews/MapViewModel.swift
@@ -94,7 +94,11 @@ final class MapViewModel: NSObject, CLLocationManagerDelegate,ObservableObject {
                     locations.append(location)
                 }
             } catch {
-                errorMessage = "\((error as! ApiError).customDescription)"
+                if let apiError = error as? ApiError {
+                    errorMessage = apiError.customDescription
+                } else {
+                    errorMessage = error.localizedDescription
+                }
                 hasError = true
             }
     }


### PR DESCRIPTION
## Summary
- avoid force casting of `error` to `ApiError` in `MapViewModel.fetchEvents`
- fall back to `localizedDescription` when cast fails

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb84b9ec48328b4215c8e73dc1b97