### PR TITLE
Fix parental controls message

### DIFF
--- a/FindMyUltra/Views/MapViews/MapViewModel.swift
+++ b/FindMyUltra/Views/MapViews/MapViewModel.swift
@@ -53,10 +53,10 @@ final class MapViewModel: NSObject, CLLocationManagerDelegate,ObservableObject {
             locationManger.requestWhenInUseAuthorization()
         case .restricted:
             showAlert = true
-            print("Location is restricted parental conrolls")
+            print("Location is restricted parental controls")
         case .denied:
             showAlert = true
-            print("Location is restricted parental conrolls")
+            print("Location is restricted parental controls")
         case .authorizedAlways, .authorizedWhenInUse:
             if let location = locationManger.location {
                 if selectedAddress != nil {


### PR DESCRIPTION
## Summary
- fix typos in MapViewModel

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb84cb77c8328bd7f7bece2b5ce18