### PR TITLE
Add MapViewModel request query item test

### DIFF
--- a/FindMyUltraTests/FindMyUltraTests.swift
+++ b/FindMyUltraTests/FindMyUltraTests.swift
@@ -33,4 +33,26 @@ final class FindMyUltraTests: XCTestCase {
         }
     }
 
+    func testRequestIncludesAnnotationQueryItems() throws {
+        let viewModel = MapViewModel()
+        let latitude = 37.0
+        let longitude = -122.0
+        viewModel.annotationItems = [AnnotationItem(latitude: latitude, longitude: longitude)]
+        viewModel.distanceFromMe = .twoHundred
+
+        let request = viewModel.request()
+        guard let url = request.url,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            XCTFail("Missing url or query items")
+            return
+        }
+
+        let queryDictionary = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+        XCTAssertEqual(queryDictionary["lat"], String(describing: latitude))
+        XCTAssertEqual(queryDictionary["lng"], String(describing: longitude))
+        XCTAssertEqual(queryDictionary["mi"], viewModel.distanceFromMe.network)
+    }
+
 }


### PR DESCRIPTION
## Summary
- add unit test for request generation using annotation items

## Testing
- `xcodebuild test -scheme FindMyUltra -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb8508738832895c23e28c25ff0d7