### PR TITLE
Add difficulty filter

### DIFF
--- a/FindMyUltra/Views/FilterView/FilterView.swift
+++ b/FindMyUltra/Views/FilterView/FilterView.swift
@@ -56,6 +56,13 @@ struct FilterView: View {
                     }
                 }
                 .pickerStyle(.automatic)
+                Picker("Difficulty", selection: $viewModel.difficulty) {
+                    ForEach(Difficulty.allCases) { option in
+                        Text(String(describing: option))
+                            .tag(option)
+                    }
+                }
+                .pickerStyle(.automatic)
                 Picker("Distance", selection: $viewModel.raceDistance) {
                     ForEach(RaceDistance.allCases) { option in
                         Text(String(describing: option))

--- a/FindMyUltra/Views/MapViews/MapViewModel.swift
+++ b/FindMyUltra/Views/MapViews/MapViewModel.swift
@@ -25,7 +25,7 @@ final class MapViewModel: NSObject, CLLocationManagerDelegate,ObservableObject {
     @Published private(set) var events: [Event] = []
     @Published private(set) var errorMessage: String = ""
     @Published var hasError: Bool = false
-    @Published var difficultyPicker: Difficulty = .unranked
+    @Published var difficulty: Difficulty = .unranked
     @Published var raceDistance: RaceDistance = .showAll
     @Published var distanceFromMe: DistanceFromMe = .twoHundred
     @Published var month: Month = .showAll
@@ -138,6 +138,10 @@ final class MapViewModel: NSObject, CLLocationManagerDelegate,ObservableObject {
         if month != .showAll {
             let m = URLQueryItem(name: "m", value: month.network)
             request.url?.append(queryItems: [m])
+        }
+        if difficulty != .unranked {
+            let diff = URLQueryItem(name: "difficulty", value: difficulty.network)
+            request.url?.append(queryItems: [diff])
         }
         return request
     }

--- a/FindMyUltraTests/MapViewModelTests.swift
+++ b/FindMyUltraTests/MapViewModelTests.swift
@@ -24,4 +24,16 @@ final class MapViewModelTests: XCTestCase {
         XCTAssertEqual(value(for: "open"), "1")
         XCTAssertEqual(value(for: "past"), "0")
     }
+
+    func testRequestIncludesDifficulty() {
+        let viewModel = MapViewModel()
+        viewModel.difficulty = .easy
+        let request = viewModel.request()
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        func value(for name: String) -> String? {
+            return queryItems.first(where: { $0.name == name })?.value
+        }
+        XCTAssertEqual(value(for: "difficulty"), Difficulty.easy.network)
+    }
 }


### PR DESCRIPTION
## Summary
- add difficulty picker and include difficulty parameter in `MapViewModel`
- update map view model to use new difficulty property
- add tests for difficulty query item

## Testing
- `xcodebuild test -workspace FindMyUltra.xcodeproj/project.xcworkspace -scheme FindMyUltra -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe4d6d888328be6b2c225f4d67a9