### PR TITLE
Fix unicode escape in RaceList

### DIFF
--- a/FindMyUltra/Views/RaceList/RaceList.swift
+++ b/FindMyUltra/Views/RaceList/RaceList.swift
@@ -56,7 +56,7 @@ struct RaceList: View {
                                     .font(.headline)
                                     .fontWeight(.semibold)
                                     .lineLimit(1)
-                                Label("\(event.distances) \u00b7 \(event.city), \(event.state) \u00b7 \(event.eventDate)", systemImage: "figure.run")
+                                Label("\(event.distances) \u{00B7} \(event.city), \(event.state) \u{00B7} \(event.eventDate)", systemImage: "figure.run")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }


### PR DESCRIPTION
## Summary
- fix unicode escape sequences in RaceList.swift

## Testing
- `xcodebuild -list -project FindMyUltra.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684060aec15c8328b4f367a59572488c