### PR TITLE
refactor: replace NavigationView with NavigationStack

### DIFF
--- a/FindMyUltra/Views/MapViews/MapView.swift
+++ b/FindMyUltra/Views/MapViews/MapView.swift
@@ -79,15 +79,18 @@ struct MapView: View {
                     }
                 }
                 .sheet(isPresented: $showAnotherSheet) {
-                    NavigationView {
+                    NavigationStack {
                         FilterView(viewModel: viewModel)
-                            .navigationBarItems(trailing: Button("Apply Filters",
-                                                                 action: {showAnotherSheet.toggle()
-                                if let address = viewModel.selectedAddress {
-                                    viewModel.getPlace(from: address)
+                            .toolbar {
+                                ToolbarItem(placement: .topBarTrailing) {
+                                    Button("Apply Filters", action: {
+                                        showAnotherSheet.toggle()
+                                        if let address = viewModel.selectedAddress {
+                                            viewModel.getPlace(from: address)
+                                        }
+                                    })
                                 }
-                            
-                            }))
+                            }
                     }
                 }
                 .overlay(alignment: .bottomTrailing, content: {

--- a/FindMyUltra/Views/RaceList/RaceList.swift
+++ b/FindMyUltra/Views/RaceList/RaceList.swift
@@ -87,15 +87,18 @@ struct RaceList: View {
             
         }
         .sheet(isPresented: $showAnotherSheet) {
-            NavigationView {
-              FilterView(viewModel: viewModel)
-                    .navigationBarItems(trailing: Button("Apply Filters",
-                                                         action: {showAnotherSheet.toggle()
-                        Task{
-                            await
-                            viewModel.fetchEvents()
+            NavigationStack {
+                FilterView(viewModel: viewModel)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button("Apply Filters", action: {
+                                showAnotherSheet.toggle()
+                                Task {
+                                    await viewModel.fetchEvents()
+                                }
+                            })
                         }
-                    }))
+                    }
             }
         }
        


### PR DESCRIPTION
## Summary
- update filter sheets to use `NavigationStack`
- adopt modern `.toolbar` API for filter actions

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689f5be47824832884c52012d02aa430