### PR TITLE
Replace MapCameraPosition with MKCoordinateRegion Map

### DIFF
--- a/FindMyUltra/Home.swift
+++ b/FindMyUltra/Home.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct Home: View {
     @StateObject private var viewModel = MapViewModel()
+    @Environment(\.openURL) private var openURL
     var body: some View {
         TabView {
             MapView(viewModel: viewModel)
@@ -22,13 +23,17 @@ struct Home: View {
                 }
         }
         .alert(isPresented: $viewModel.showAlert) {
-             Alert (title: Text("Location Access is required to find races near you on the Map"),
-                    message: Text("Go to Settings?"),
-                    primaryButton: .default(Text("Settings"), action: {
-                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-                    }),
-                    secondaryButton: .default(Text("Cancel")))
-                }
+            Alert(
+                title: Text("Location Access is required to find races near you on the Map"),
+                message: Text("Go to Settings?"),
+                primaryButton: .default(Text("Settings"), action: {
+                    if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(settingsURL)
+                    }
+                }),
+                secondaryButton: .default(Text("Cancel"))
+            )
+        }
         .accentColor(.indigo)
         .task {
            

--- a/FindMyUltra/Info.plist
+++ b/FindMyUltra/Info.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>FindMyUltra uses your location to show races near you on the map.</string>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>FindMyUltra uses your location to show races near you on the map.</string>
+</dict>
 </plist>

--- a/FindMyUltra/Views/MapViews/MapViewModel.swift
+++ b/FindMyUltra/Views/MapViews/MapViewModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import MapKit
-import _MapKit_SwiftUI
 
 enum MapDetails {
     static let startingLocation = CLLocationCoordinate2D(latitude: 37.331516, longitude: -121.8911054)
@@ -19,7 +18,6 @@ final class MapViewModel: NSObject, CLLocationManagerDelegate,ObservableObject {
     var locationManger: CLLocationManager?
     @Published var region = MKCoordinateRegion(center: MapDetails.startingLocation, span: MapDetails.defaultSpan)
     @Published var selectedAddress: AddressResult?
-    @Published var camameraPosition = MapCameraPosition.region(MKCoordinateRegion(center: MapDetails.startingLocation, span: MapDetails.defaultSpan))
     @Published var data: [MapViewDO] = []
     @Published var locations: [Location] = []
     @Published private(set) var events: [Event] = []
@@ -74,10 +72,9 @@ final class MapViewModel: NSObject, CLLocationManagerDelegate,ObservableObject {
         Task { @MainActor in
             guard let location = locations.last else { return }
             if self.selectedAddress != nil {
-                self.camameraPosition = MapCameraPosition.region(MKCoordinateRegion(center: self.region.center, span: MKCoordinateSpan(latitudeDelta: 1.05, longitudeDelta: 1.05)))
+                self.region = MKCoordinateRegion(center: self.region.center, span: MKCoordinateSpan(latitudeDelta: 1.05, longitudeDelta: 1.05))
             } else {
                 self.region = MKCoordinateRegion(center: location.coordinate, span: MKCoordinateSpan(latitudeDelta: 1.05, longitudeDelta: 1.05))
-                self.camameraPosition = MapCameraPosition.region(MKCoordinateRegion(center: location.coordinate, span: MKCoordinateSpan(latitudeDelta: 1.05, longitudeDelta: 1.05)))
             }
             self.locationManger?.stopUpdatingLocation()
         }


### PR DESCRIPTION
## Summary
- switch the map to use MKCoordinateRegion bindings instead of MapCameraPosition
- consolidate event and home annotations into a single Map annotation list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ab61f084832888c778560fede8e8)